### PR TITLE
update scavenger and pesterminator max levels

### DIFF
--- a/src/main/resources/enchants.json
+++ b/src/main/resources/enchants.json
@@ -345,7 +345,7 @@
     "pesterminator": {
       "goodLevel": 0,
       "loreName": "Pesterminator",
-      "maxLevel": 5,
+      "maxLevel": 6,
       "nbtName": "pesterminator"
     },
     "piercing": {
@@ -447,7 +447,7 @@
     "scavenger": {
       "goodLevel": 3,
       "loreName": "Scavenger",
-      "maxLevel": 5,
+      "maxLevel": 6,
       "nbtName": "scavenger"
     },
     "sharpness": {


### PR DESCRIPTION
Golden Bounty allows you to upgrade Scavenger 5 enchant on an item to Scavenger 6. (Stock of Stonks update from a while ago)

A Beginner's Guide to Pesthunting, purchasable from Pesthunter Philip's shop for 500 Pests (or from BZ) allows you to upgrade Pesterminator 5 enchant on an item to Pesterminator 6. (Last update)