### PR TITLE
Prevent IndexOutOfBoundsException in SkyblockKeyBinding#isKeyDown on Linux

### DIFF
--- a/src/main/java/codes/biscuit/skyblockaddons/core/SkyblockKeyBinding.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/core/SkyblockKeyBinding.java
@@ -63,21 +63,13 @@ public enum SkyblockKeyBinding {
      */
     public boolean isKeyDown() {
         int keyCode = this.getKeyCode();
-        
-        if (!registered || keyCode == 9999) {
-            return false;
-        }
+        if (!registered || keyCode == 9999) return false;
 
         if (keyCode < 0) {
-            int button = keyCode + 100;
-            if (button < 0 || button >= Mouse.getButtonCount()) {
-                return false;
-            }
-            return Mouse.isButtonDown(button);
+            return Mouse.isButtonDown(keyCode + 100);
         }
-
-        int keyCount = Keyboard.getKeyCount();
-        if (keyCode >= keyCount) {
+        
+        if (keyCode >= Keyboard.getKeyCount()) {
             return false;
         }
         return Keyboard.isKeyDown(keyCode);

--- a/src/main/java/codes/biscuit/skyblockaddons/core/SkyblockKeyBinding.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/core/SkyblockKeyBinding.java
@@ -63,16 +63,24 @@ public enum SkyblockKeyBinding {
      */
     public boolean isKeyDown() {
         int keyCode = this.getKeyCode();
-
-        if (registered && keyCode != 9999) {
-            if (keyCode < 0) {
-                return Mouse.isButtonDown(keyCode + 100);
-            } else {
-                return Keyboard.isKeyDown(keyCode);
-            }
-        } else {
+        
+        if (!registered || keyCode == 9999) {
             return false;
         }
+
+        if (keyCode < 0) {
+            int button = keyCode + 100;
+            if (button < 0 || button >= Mouse.getButtonCount()) {
+                return false;
+            }
+            return Mouse.isButtonDown(button);
+        }
+
+        int keyCount = Keyboard.getKeyCount();
+        if (keyCode >= keyCount) {
+            return false;
+        }
+        return Keyboard.isKeyDown(keyCode);
     }
 
     /**


### PR DESCRIPTION
Previously, `SkyblockKeyBinding.isKeyDown()` called `Keyboard.isKeyDown(keyCode)` without
checking that `keyCode` was within the valid range (`0 ≤ keyCode < Keyboard.getKeyCount()`).
On Linux—especially with lower JVM RAM allocations leading to a smaller LWJGL key buffer—this
could result in `keyCode >= keyCount`, throwing an `IndexOutOfBoundsException` and causing
sporadic crashes in all GUIs (inventory, chests, pause menu, etc.). This commit adds a simple
guard to return `false` for any out‑of‑range key codes, fully preventing the crash.