### PR TITLE
Allow copying chat ouside of SkyBlock

### DIFF
--- a/src/main/java/com/fix3dll/skyblockaddons/mixin/hooks/ChatScreenHook.java
+++ b/src/main/java/com/fix3dll/skyblockaddons/mixin/hooks/ChatScreenHook.java
@@ -30,8 +30,7 @@ public class ChatScreenHook {
 
     public static void copyChatMessage(MouseButtonEvent event, boolean isDoubleClick, CallbackInfoReturnable<Boolean> cir) {
         if (event.button() != 0) return;
-        if (Feature.DEVELOPER_MODE.isDisabled()
-                && (Feature.CHAT_MESSAGE_COPYING.isDisabled() || !main.getUtils().isOnSkyblock())) {
+        if (Feature.DEVELOPER_MODE.isDisabled() && Feature.CHAT_MESSAGE_COPYING.isDisabled()) {
             return;
         }
 


### PR DESCRIPTION
Small change that really bothered me since I couldn't copy the chat while I was in the lobby, and I don't really want to have developer mode on all the time.