### PR TITLE
fix: equipment & stats menu regex for 0.26.1 update

### DIFF
--- a/src/main/resources/regex.json
+++ b/src/main/resources/regex.json
@@ -107,7 +107,7 @@
   "MAYOR": "Mayor (?<mayor>.*)",
   "CALENDAR": "Calendar and Events",
   "PETS": "(?:\\((?<page>\\d+)/\\d+\\) +)?Pets *",
-  "EQUIPMENT": "Your Equipment and Stats",
+  "EQUIPMENT": "Stats & Equipment",
   "SKYBLOCK_MENU": "SkyBlock Menu",
   "CATACOMBS_CHEST": "(?<type>Wood|Gold|Diamond|Emerald|Obsidian|Bedrock)",
   "KUUDRA_CHEST": "(?<type>Free|Paid) Chest",


### PR DESCRIPTION
It will not be merged until version 0.26.1 is released.